### PR TITLE
Threads summaries

### DIFF
--- a/commands/xp.js
+++ b/commands/xp.js
@@ -171,7 +171,7 @@ module.exports = {
       return interaction.editReply(
         `${group === "add" ? "Added" : "Removed"} \`${amount}\` XP ${
           group === "add" ? "to" : "from"
-        } **${username}**'s bank${mission ? ` from **${mission}**` : ""}.`
+        } **${username}**'s bank${mission ? ` from **${mission}**` : ""}. You now have \`${newExperience}\` XP in your bank.`
       );
     }
 


### PR DESCRIPTION
This pull request enhances the functionality of the `summarize` command to support threads in addition to channels, improves the formatting of summary titles, and adds detailed metadata for thread summaries. Additionally, a minor improvement is made to the `xp` command to provide more informative feedback.

### Enhancements to the `summarize` command:
* Added a `formatTitle` function to dynamically format titles based on whether the input is a channel or a thread.
* Updated the `summarize` command to support thread types (`PublicThread`, `PrivateThread`, `AnnouncementThread`) in addition to text channels.
* Replaced static summary titles with `formatTitle` in multiple locations to ensure consistent formatting across embeds. [[1]](diffhunk://#diff-8840a557d9071042ed6597464f9423ba22b7c2caa4d24e96401b7c8b3d63dba3L61-R75) [[2]](diffhunk://#diff-8840a557d9071042ed6597464f9423ba22b7c2caa4d24e96401b7c8b3d63dba3L135-R149) [[3]](diffhunk://#diff-8840a557d9071042ed6597464f9423ba22b7c2caa4d24e96401b7c8b3d63dba3L425-R444) [[4]](diffhunk://#diff-8840a557d9071042ed6597464f9423ba22b7c2caa4d24e96401b7c8b3d63dba3L519-R538)
* Added thread-specific metadata (`isThread`, `parentChannelId`, `parentChannelName`, `threadType`) to the summary payload for better context and traceability.

### Improvement to the `xp` command:
* Enhanced feedback to include the user's updated XP balance after adding or removing XP.